### PR TITLE
Removed options that prevent the disconnect from working

### DIFF
--- a/AzureConnectedMachineDsc.psd1
+++ b/AzureConnectedMachineDsc.psd1
@@ -9,7 +9,7 @@
 @{
 
 # Version number of this module.
-ModuleVersion = '1.0.1.0'
+ModuleVersion = '1.0.2.0'
 
 # ID used to uniquely identify this module
 GUID = '4e7bcccd-6002-47b5-8b9f-fcca5975d445'

--- a/DSCResources/Helpers.psm1
+++ b/DSCResources/Helpers.psm1
@@ -31,10 +31,6 @@ function Connect-AzConnectedMachineAgent {
         if (Test-AzConnectedMachineAgentConnection) {
             Write-Verbose "Machine $env:COMPUTERNAME is already onboarded.  Disconnecting, restarting service, and reconnecting."
             & azcmagent disconnect `
-                --resource-name $env:COMPUTERNAME `
-                --tenant-id $TenantId `
-                --subscription-id $SubscriptionId `
-                --resource-group $ResourceGroup `
                 --service-principal-id $Credential.UserName `
                 --service-principal-secret $Credential.GetNetworkCredential().Password
             Restart-Service 'HIMDS' -Force

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+**1.0.2.0**
+
+- Fixed error when reconnecting ARC agent
+
 **1.0.1.0**
 
 - Fixed links in manifest 

--- a/examples/AzureConnectedMachineAgent.ps1
+++ b/examples/AzureConnectedMachineAgent.ps1
@@ -37,7 +37,7 @@ Configuration AzureConnectedMachineAgent {
         [PSCredential]$Credential
     )
     Import-DscResource -ModuleName PSDSCResources
-    Import-DscResource -Module @{ModuleName = 'AzureConnectedMachineDsc'; ModuleVersion = '1.0.0.0'}
+    Import-DscResource -Module @{ModuleName = 'AzureConnectedMachineDsc'; ModuleVersion = '1.0.2.0'}
 
     Node $AllNodes.NodeName
     {


### PR DESCRIPTION
These options that I've removed aren't available in the azcmagent.exe disconnect command. I've tested without these options and it works fine, I've also ran all tests and they're passing.

Fixes issue https://github.com/Azure/AzureConnectedMachineDsc/issues/2