### PR TITLE
Added ability to replace ARC machines, fixes disconnect and reports errors

### DIFF
--- a/AzureConnectedMachineDsc.psd1
+++ b/AzureConnectedMachineDsc.psd1
@@ -9,7 +9,7 @@
 @{
 
 # Version number of this module.
-ModuleVersion = '1.0.1.0'
+ModuleVersion = '1.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = '4e7bcccd-6002-47b5-8b9f-fcca5975d445'

--- a/DSCResources/MSFT_AzureConnectedMachineAgentDsc/MSFT_AzureConnectedMachineAgentDsc.psm1
+++ b/DSCResources/MSFT_AzureConnectedMachineAgentDsc/MSFT_AzureConnectedMachineAgentDsc.psm1
@@ -18,7 +18,9 @@ function Get-TargetResource {
         [string]$Tags,
 
         [Parameter(Mandatory = $true)]
-        [PSCredential]$Credential
+        [PSCredential]$Credential,
+
+        [bool]$ForceReplaceAgent = $false
     )
 
     $AzConnectedMachineAgent = Get-AzConnectedMachineAgent
@@ -91,7 +93,9 @@ function Set-TargetResource {
         [string]$Tags,
 
         [Parameter(Mandatory = $true)]
-        [PSCredential]$Credential
+        [PSCredential]$Credential,
+
+        [bool]$ForceReplaceAgent = $false
     )
 
     Connect-AzConnectedMachineAgent @PSBoundParameters
@@ -115,7 +119,9 @@ function Test-TargetResource {
         [string]$Tags,
 
         [Parameter(Mandatory = $true)]
-        [PSCredential]$Credential
+        [PSCredential]$Credential,
+
+        [bool]$ForceReplaceAgent = $false
     )
     $Params =
     @{

--- a/DSCResources/MSFT_AzureConnectedMachineAgentDsc/MSFT_AzureConnectedMachineAgentDsc.schema.mof
+++ b/DSCResources/MSFT_AzureConnectedMachineAgentDsc/MSFT_AzureConnectedMachineAgentDsc.schema.mof
@@ -6,6 +6,7 @@ class MSFT_AzureConnectedMachineAgentDsc : OMI_BaseResource
     [Required, Description("The name of the Azure Resource Group.  This can be pre-created using New-AzResourceGroup.")] String ResourceGroup;
     [Required, Description("The Azure location name where the machine resource should be created.  The available list of locations can be found using 'Get-AzResourceProvider -ProviderNamespace Microsoft.HybridCompute'.")] String Location;
     [Write, Description("The tags to be applied to the machine resource.  This is formatted as 'property=value,property=value'")] String Tags;
+    [Write, Description("If an agent with the same name already exists in the resource group, force a delete of the existing resource before connecting.")] Boolean ForceReplaceAgent;
     [Required, Description("The Application ID and Secret stored as a Credential object."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Read, EmbeddedInstance("Reason")] String Reasons[];
 };

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+**1.1.0.0**
+
+- Added optional parameter ForceReplaceAgent that uses the credentials supplied to delete an existing ARC agent with the same subscription, resource group and name in Azure before registering the agent
+- Reports any errors to the DSC logs
+- Calls azcmagent with correct parameters to disconnect successfully when needed
+
 **1.0.1.0**
 
 - Fixed links in manifest 

--- a/examples/AzureConnectedMachineAgent.ps1
+++ b/examples/AzureConnectedMachineAgent.ps1
@@ -37,7 +37,7 @@ Configuration AzureConnectedMachineAgent {
         [PSCredential]$Credential
     )
     Import-DscResource -ModuleName PSDSCResources
-    Import-DscResource -Module @{ModuleName = 'AzureConnectedMachineDsc'; ModuleVersion = '1.0.0.0'}
+    Import-DscResource -Module @{ModuleName = 'AzureConnectedMachineDsc'; ModuleVersion = '1.1.0.0'}
 
     Node $AllNodes.NodeName
     {


### PR DESCRIPTION
If the `ForceReplaceAgent` parameter is specified and the agent isn't
connected it will check for any existing agents in the same resource
group and subscription with the same name and if it finds any it will
delete them from Azure using the Arc credentials specified and the Azure
REST API.

Fixes an error in the disconnect step where it was previously supplying
the wrong parameters to `azcmagent`.

Reports any errors to stdout now so DSC reports them to the end user.
Previously they were being swallowed by the process itself and it wasn't
clear why things were failing.